### PR TITLE
fix: 채팅에 한글 입력시 마지막 글자가 중복으로 입력되는 오류 수정 

### DIFF
--- a/src/pages/test/TestChat.tsx
+++ b/src/pages/test/TestChat.tsx
@@ -78,6 +78,10 @@ export default function TestChat({ testNo }: Props) {
   });
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
+    if (e.nativeEvent.isComposing) {
+      e.stopPropagation();
+      return;
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       createMessageMutation.mutate(formData);


### PR DESCRIPTION
## 📌 작업사항

- closes #80 

## 💌 참고사항

## 📸 스크린샷
